### PR TITLE
JS-validation for Checkout agreements (if credit card is payment method)

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/base.js
+++ b/view/frontend/web/js/view/payment/method-renderer/base.js
@@ -41,8 +41,14 @@ define(
             },
             
             handleCreditcardPayment: function () {
-                if (this.validate() && additionalValidators.validate() && document.getElementById(this.getCode() + '_pseudocardpan').value == '') {
-                    // update payment method information if additional data was changed
+                var firstValidation = additionalValidators.validate();
+                if (!(firstValidation)) {
+                    return false;
+                }
+
+                // if (this.validate() && additionalValidators.validate() && document.getElementById(this.getCode() + '_pseudocardpan').value == '') {
+                if (this.validate() && firstValidation) {
+                        // update payment method information if additional data was changed
                     this.selectPaymentMethod();
                     handleRedirectAction(this.getData(), this.messageContainer);
                     return false;


### PR DESCRIPTION
For credit card the validation of checkout agreements does not work.

We have a setup with the usual checkout agreements for Germany, meaning you have to accept the business terms (AGB) and privacy (datenschutzvereinbarung). For that we have implemented the needed checkout agreements in magento admin (Stores --> Terms and Condition)

For payment methods other than payone credit card, there is a javscript validation that usually works.

In order to get checkout agreements to work for credit card, I modified the function handleCreditcardPayment (lines 44 and following)