### PR TITLE
http(s) for admin/payone/information

### DIFF
--- a/Block/Adminhtml/Information.php
+++ b/Block/Adminhtml/Information.php
@@ -57,6 +57,6 @@ class Information extends \Magento\Backend\Block\Template
      */
     public function getPayoneUrl()
     {
-        return 'http://www.payone.de/embedded-sites/magento/information/';
+        return '//www.payone.de/embedded-sites/magento/information/';
     }
 }


### PR DESCRIPTION
admin/payone/information fails on https sites due to hardcoded protocol

Was accidentally removed.