### PR TITLE
Kreditkartenzahlung: Fehlermeldung wenn kein Verfallsdatum eingegeben wurde.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/creditcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcard-method.js
@@ -146,7 +146,7 @@ define(
                     // PseudoCardPan; then call your function "payCallback"
                     fullScreenLoader.startLoader();
                 } else {
-                    console.debug("not complete");
+                    this.messageContainer.addErrorMessage({'message': $t("Please enter complete data.")});
                 }
             },
             


### PR DESCRIPTION
Wenn ich als Kunde eine Bestellung per Kreditkarte durchführen möchte, aber vergessen habe, das Verfallsdatum einzugeben, wird keine Fehlermeldung angezeigt.
Stattdessen wird nur eine Ausgabe in der Browser-Konsole ausgegeben:
`console.debug("not complete");`
In diesem Patch wird dies ersetzt durch eine Magento-Fehlermeldung