### PR TITLE
fix transaction status forwarding with multiple IPs

### DIFF
--- a/Helper/Environment.php
+++ b/Helper/Environment.php
@@ -61,6 +61,7 @@ class Environment extends \Payone\Core\Helper\Base
         $sRemoteIp = $this->getRemoteIp();
         $sValidIps = $this->getConfigParam('valid_ips', 'processing', 'payone_misc');
         $aWhitelist = explode("\n", $sValidIps);
+        $aWhitelist = array_filter(array_map('trim', $aWhitelist));
         if (array_search($sRemoteIp, $aWhitelist) !== false) {
             return true;
         }


### PR DESCRIPTION
1. To use transaction forwarding you have to add the IP address of the forwarding server to the "Valid PAYONE IPs" configuration setting. Although it's quite obvious once you know it, it took me a while to figure this out, so adding a little hint in the configs's description would be helpful.

2. When I added a third IP address it stopped working for the second IP address. Dumping $aWhitelist in Helper\Environment.php line 64 shows that it's due to linebreaks from the textarea

array(3) {
  [0]=>
  string(12) "185.60.20.*
"
  [1]=>
  string(11) "173.194.219.94
"
  [2]=>
  string(9) "127.0.0.1"
}

Works only for the last IP address or if the IP address contains a wildcard.

