### PR TITLE
new event payone_core_transactionstatus_paid breaks transaction status forwarding

### DIFF
--- a/Observer/Transactionstatus/Paid.php
+++ b/Observer/Transactionstatus/Paid.php
@@ -64,6 +64,11 @@ class Paid implements ObserverInterface
         /* @var $oOrder Order */
         $oOrder = $observer->getOrder();
 
+        // order is not guaranteed to exist if using transaction status forwarding
+        if (null === $oOrder){
+            return;
+        }
+
         $oInvoice = $this->invoiceService->prepareInvoice($oOrder);
         $oInvoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
         $oInvoice->setTransactionId($oOrder->getPayment()->getLastTransId());


### PR DESCRIPTION
Forwarding server throws an error if order does not exist and cannot return "TSOK".