### PR TITLE
0034698 - We received a support-case, stating that the PAYONE Magento…

### DIFF
--- a/Observer/CheckoutSubmitBefore.php
+++ b/Observer/CheckoutSubmitBefore.php
@@ -205,6 +205,10 @@ class CheckoutSubmitBefore implements ObserverInterface
     {
         /** @var Quote $oQuote */
         $oQuote = $observer->getQuote();
+        if (!$oQuote) {
+            return;
+        }
+
         $oBilling = $oQuote->getBillingAddress();
         $oShipping = $oQuote->getShippingAddress();
 


### PR DESCRIPTION
… 2 extension creates a problem with the Billpay Magento 2 extension.

The Billpay extension is using the "checkout_submit_before" event in the wrong way by not sending the same parameters as the Magento-Core does. Therefore breaking the PAYONE method using the same event.

I added an if-statement to check if the needed quote object was given to the event observer, so that both extensions can co-exist and so that no other extension can break the PAYONE method by sending the wrong parameters.