### PR TITLE
Fix for #157: wrong currency transmitted

### DIFF
--- a/Helper/Toolkit.php
+++ b/Helper/Toolkit.php
@@ -51,7 +51,6 @@ class Toolkit extends \Payone\Core\Helper\Base
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Payone\Core\Helper\Payment                $paymentHelper
      * @param \Payone\Core\Helper\Shop                   $shopHelper
-     * @param CurrencyFactory                            $currencyFactory
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,

--- a/Helper/Toolkit.php
+++ b/Helper/Toolkit.php
@@ -26,7 +26,6 @@
 
 namespace Payone\Core\Helper;
 
-use Magento\Directory\Model\CurrencyFactory;
 use Magento\Framework\DataObject;
 use Magento\Sales\Model\Order as SalesOrder;
 use Magento\Store\Model\Store;

--- a/Helper/Toolkit.php
+++ b/Helper/Toolkit.php
@@ -43,10 +43,6 @@ class Toolkit extends \Payone\Core\Helper\Base
      * @var \Payone\Core\Helper\Payment
      */
     protected $paymentHelper;
-    /**
-     * @var CurrencyFactory
-     */
-    protected $currencyFactory;
 
     /**
      * Constructor
@@ -61,12 +57,10 @@ class Toolkit extends \Payone\Core\Helper\Base
         \Magento\Framework\App\Helper\Context $context,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Payone\Core\Helper\Payment $paymentHelper,
-        \Payone\Core\Helper\Shop $shopHelper,
-        CurrencyFactory $currencyFactory
+        \Payone\Core\Helper\Shop $shopHelper
     ) {
         parent::__construct($context, $storeManager, $shopHelper);
         $this->paymentHelper = $paymentHelper;
-        $this->currencyFactory = $currencyFactory;
     }
 
     /**

--- a/Model/Api/Request/Authorization.php
+++ b/Model/Api/Request/Authorization.php
@@ -151,8 +151,10 @@ class Authorization extends AddressRequest
         $sRefNr = $this->shopHelper->getConfigParam('ref_prefix').$oOrder->getIncrementId(); // ref_prefix to prevent duplicate refnumbers in testing environments
         $sRefNr = $oPayment->formatReferenceNumber($sRefNr); // some payment methods have refnr regulations
         $this->addParameter('reference', $sRefNr); // add ref-nr to request
-        $this->addParameter('amount', number_format($dAmount, 2, '.', '') * 100); // add price to request
-        $this->addParameter('currency', $oOrder->getOrderCurrencyCode()); // add currency to request
+        $this->addParameter('amount', number_format(
+            $this->toolkitHelper->convertToTransmitCurrency($dAmount), 2, '.', '') * 100
+        ); // add price to request
+        $this->addParameter('currency', $this->toolkitHelper->getTransmitCurrencyCode()); // add currency to request
         if ($this->shopHelper->getConfigParam('transmit_ip') == '1') {// is IP transmission needed?
             $sIp = $this->environmentHelper->getRemoteIp(); // get remote IP
             if ($sIp != '') {// is IP not empty

--- a/Model/Api/Request/Capture.php
+++ b/Model/Api/Request/Capture.php
@@ -48,6 +48,13 @@ class Capture extends Base
     protected $databaseHelper;
 
     /**
+     * PAYONE toolkit helper
+     *
+     * @var \Payone\Core\Helper\Toolkit
+     */
+    protected $toolkitHelper;
+
+    /**
      * Constructor
      *
      * @param \Payone\Core\Helper\Shop                $shopHelper
@@ -63,7 +70,8 @@ class Capture extends Base
         \Payone\Core\Helper\Api $apiHelper,
         \Payone\Core\Model\ResourceModel\ApiLog $apiLog,
         \Payone\Core\Model\Api\Invoice $invoiceGenerator,
-        \Payone\Core\Helper\Database $databaseHelper
+        \Payone\Core\Helper\Database $databaseHelper,
+        \Payone\Core\Helper\Toolkit $toolkitHelper
     ) {
         parent::__construct($shopHelper, $environmentHelper, $apiHelper, $apiLog);
         $this->invoiceGenerator = $invoiceGenerator;
@@ -123,8 +131,10 @@ class Capture extends Base
         $this->addParameter('language', $this->shopHelper->getLocale());
 
         // Total order sum in smallest currency unit
-        $this->addParameter('amount', number_format($dAmount, 2, '.', '') * 100);
-        $this->addParameter('currency', $oOrder->getOrderCurrencyCode()); // Currency
+        $this->addParameter('amount', number_format(
+            $this->toolkitHelper->convertToTransmitCurrency($dAmount), 2, '.', '') * 100
+        );
+        $this->addParameter('currency', $this->toolkitHelper->getTransmitCurrencyCode()); // Currency
 
         $this->addParameter('txid', $iTxid); // PayOne Transaction ID
         $this->addParameter('sequencenumber', $this->databaseHelper->getSequenceNumber($iTxid));

--- a/Model/Api/Request/Capture.php
+++ b/Model/Api/Request/Capture.php
@@ -63,6 +63,7 @@ class Capture extends Base
      * @param \Payone\Core\Model\ResourceModel\ApiLog $apiLog
      * @param \Payone\Core\Model\Api\Invoice          $invoiceGenerator
      * @param \Payone\Core\Helper\Database            $databaseHelper
+     * @param \Payone\Core\Helper\Toolkit             $toolkitHelper
      */
     public function __construct(
         \Payone\Core\Helper\Shop $shopHelper,
@@ -76,6 +77,7 @@ class Capture extends Base
         parent::__construct($shopHelper, $environmentHelper, $apiHelper, $apiLog);
         $this->invoiceGenerator = $invoiceGenerator;
         $this->databaseHelper = $databaseHelper;
+        $this->toolkitHelper = $toolkitHelper;
     }
 
     /**

--- a/Model/Api/Request/Debit.php
+++ b/Model/Api/Request/Debit.php
@@ -151,8 +151,11 @@ class Debit extends Base
         $this->addParameter('sequencenumber', $this->databaseHelper->getSequenceNumber($iTxid));
 
         // Total order sum in smallest currency unit
-        $this->addParameter('amount', number_format((-1 * $dAmount), 2, '.', '') * 100);
-        $this->addParameter('currency', $oOrder->getOrderCurrencyCode()); // Currency
+        $this->addParameter('amount', number_format(
+            (-1 * $this->toolkitHelper->convertToTransmitCurrency($dAmount)),
+            2, '.', '') * 100
+        );
+        $this->addParameter('currency', $this->toolkitHelper->getTransmitCurrencyCode()); // Currency
         $this->addParameter('transactiontype', 'GT');
 
         $sRefundAppendix = $this->getRefundAppendix($oOrder, $oPayment);

--- a/Model/Api/Request/Genericpayment/PreCheck.php
+++ b/Model/Api/Request/Genericpayment/PreCheck.php
@@ -35,6 +35,22 @@ use Magento\Quote\Model\Quote;
 class PreCheck extends Base
 {
     /**
+     * @var \Payone\Core\Helper\Toolkit
+     */
+    protected $toolkitHelper;
+
+    public function __construct(\Payone\Core\Helper\Shop $shopHelper,
+                                \Payone\Core\Helper\Environment $environmentHelper,
+                                \Payone\Core\Helper\Api $apiHelper,
+                                \Payone\Core\Model\ResourceModel\ApiLog $apiLog,
+                                \Payone\Core\Helper\Customer $customerHelper,
+                                \Payone\Core\Helper\Toolkit $toolkitHelper)
+    {
+        parent::__construct($shopHelper, $environmentHelper, $apiHelper, $apiLog, $customerHelper);
+        $this->toolkitHelper = $toolkitHelper;
+    }
+
+    /**
      * Send request to PAYONE Server-API with request-type "genericpayment" and action "pre_check"
      *
      * @param  PayoneMethod $oPayment payment object
@@ -57,8 +73,10 @@ class PreCheck extends Base
         $this->addParameter('financingtype', $oPayment->getSubType());
         $this->addParameter('add_paydata[payment_type]', $oPayment->getLongSubType());
 
-        $this->addParameter('amount', number_format($dAmount, 2, '.', '') * 100);
-        $this->addParameter('currency', $oQuote->getQuoteCurrencyCode());
+        $this->addParameter('amount', number_format(
+            $this->toolkitHelper->convertToTransmitCurrency($dAmount), 2, '.', '') * 100
+        );
+        $this->addParameter('currency', $this->toolkitHelper->getTransmitCurrencyCode());
 
         if ($sEmail === false) {
             $sEmail = $oQuote->getCustomerEmail();

--- a/Model/Source/Currency.php
+++ b/Model/Source/Currency.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * PAYONE Magento 2 Connector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PAYONE Magento 2 Connector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with PAYONE Magento 2 Connector. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5
+ *
+ * @category  Payone
+ * @package   Payone_Magento2_Plugin
+ * @author    FATCHIP GmbH <support@fatchip.de>
+ * @copyright 2003 - 2016 Payone GmbH
+ * @license   <http://www.gnu.org/licenses/> GNU Lesser General Public License
+ * @link      http://www.payone.de
+ */
+
+namespace Payone\Core\Model\Source;
+
+use Magento\Framework\Option\ArrayInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Source class for currency to trasmit
+ */
+class Currency implements ArrayInterface
+{
+
+    /**
+     * @var Store
+     */
+    private $store;
+
+    public function __construct(StoreManagerInterface $storeManager)
+    {
+        $this->store = $storeManager->getStore();
+    }
+
+    /**
+     * Return currency options
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => 'base',
+                'label' => __('Base Currency').' ('.$this->store->getBaseCurrencyCode().')'
+            ],
+            [
+                'value' => 'display',
+                'label' => __('Default Display Currency').' ('.$this->store->getDefaultCurrencyCode().')'
+            ]
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -63,6 +63,11 @@
                         <field id="allowspecific">1</field>
                     </depends>
                 </field>
+                <field id="currency" translate="label,comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Currency</label>
+                    <source_model>Payone\Core\Model\Source\Currency</source_model>
+                    <comment>Payment information is transmitted using the selected currency</comment>
+                </field>
                 <field id="request_type" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Authorize-method</label>
                     <source_model>Payone\Core\Model\Source\RequestType</source_model>

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -1078,3 +1078,5 @@
 "SEPA-Mandate","SEPA-Lastschriftmandat"
 "Close window","Fenster schließen"
 "Company trade registry number","Handelsregisternummer"
+
+"Payment information is transmitted using the selected currency","Zahlungsinformation wird in dieser Währung übermittelt"


### PR DESCRIPTION
Fixes #157 

- added config field to chose currency for transmission (base or default display currency)
- added two methods in Payone\Core\Helper\Toolkit:
    - **convertToTransmitCurrency($amount)** converts from base (order) currency to configured currency
    - **getTransmitCurrencyCode()** returns the corresponding currency code
- added usage of said methods to Capture, Authorization, Debit, and Precheck requests

I hope this helps fix the problem quickly. I chose the toolkit helper since it already seems to be a kind of general purpose helper. If the placement is wrong for any reason, just change it, or tell me and I will. There might be more classes that need to convert an amount, but those four were the most obvious to me.