### PR TITLE
only try to save invoice, if it exists

### DIFF
--- a/Observer/Transactionstatus/Paid.php
+++ b/Observer/Transactionstatus/Paid.php
@@ -93,10 +93,11 @@ class Paid implements ObserverInterface
         }
 
         $aInvoiceList = $oOrder->getInvoiceCollection()->getItems();
-        $oInvoice = array_shift($aInvoiceList); // get first invoice
-        $oInvoice->pay(); // mark invoice as paid
-        $oInvoice->save();
+        if ($oInvoice = array_shift($aInvoiceList)) { // get first invoice
+	        $oInvoice->pay(); // mark invoice as paid
+	        $oInvoice->save();
 
-        $oOrder->save();
+	        $oOrder->save();
+		}
     }
 }

--- a/Observer/Transactionstatus/Paid.php
+++ b/Observer/Transactionstatus/Paid.php
@@ -94,10 +94,10 @@ class Paid implements ObserverInterface
 
         $aInvoiceList = $oOrder->getInvoiceCollection()->getItems();
         if ($oInvoice = array_shift($aInvoiceList)) { // get first invoice
-	        $oInvoice->pay(); // mark invoice as paid
-	        $oInvoice->save();
+            $oInvoice->pay(); // mark invoice as paid
+	    $oInvoice->save();
 
-	        $oOrder->save();
-		}
+	    $oOrder->save();
+	}
     }
 }


### PR DESCRIPTION
In the observer that handles the "paid" transactionstatus, the $oInvoice object can be null, in which case the observer fails without notice. I'd recommend adding logging to the oberser(s), too, as it simplifies debugging. 