### PR TITLE
Order Confirmation Emails not working Fix

### DIFF
--- a/Model/Methods/PayoneMethod.php
+++ b/Model/Methods/PayoneMethod.php
@@ -115,7 +115,7 @@ abstract class PayoneMethod extends BaseMethod
     protected function sendPayoneAuthorization(InfoInterface $payment, $amount)
     {
         $oOrder = $payment->getOrder();
-        $oOrder->setCanSendNewEmailFlag(false); // dont send email now, will be sent on appointed
+        $oOrder->setCanSendNewEmailFlag(true); // dont send email now, will be sent on appointed
 
         if ($this->shopHelper->getConfigParam('currency') == 'display') {
             $amount = $oOrder->getTotalDue(); // send display amount instead of base amount


### PR DESCRIPTION
Order confirmation emails are not being sent from our site to customers. Once implementing the solution order confirmation emails started working normally. We do not find any other issues by implementing this solution.