### PR TITLE
Not cancelling APPOINTED processing anymore when email was already sent

### DIFF
--- a/Observer/Transactionstatus/Appointed.php
+++ b/Observer/Transactionstatus/Appointed.php
@@ -112,14 +112,18 @@ class Appointed implements ObserverInterface
         $oOrder = $observer->getOrder();
 
         // order is not guaranteed to exist if using transaction status forwarding
-        if (null === $oOrder || $oOrder->getEmailSent()) {
+        if (null === $oOrder) {
             return;
         }
 
-        try {
-            $this->orderSender->send($oOrder);
-        } catch (\Exception $e) {
-            $this->logger->critical($e);
+        if (!$oOrder->getEmailSent()) {
+            // the email should not have been sent at this given moment,
+            // but some custom modules may have changed this behaviour
+            try {
+                $this->orderSender->send($oOrder);
+            } catch (\Exception $e) {
+                $this->logger->critical($e);
+            }
         }
 
         // preauthorization-orders and advance payment should not create an invoice


### PR DESCRIPTION
During the handling of a support case I noticed a "GoMage OrderEmail" module on a server of a customer, which overrides Payone functionality so that the order-email is sent instantly when the order is created.

The Payone module intentionally disables the transmission of the order email in the moment when the order is created and instead sends it when the APPOINTED status arrives, because only then the payment was accepted.

In the case of the customer with the GoMage module the processing of the APPOINTED status is canceled and therefore no invoice is created, which will lead to problems in the PAID status processing, because there is no invoice available to mark as paid.

With this patch the order-email transmission logic may be wrong for customers using this kind of module but at least the order payment status isn't affected.