### PR TITLE
speed up api calls for transaction status messages

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -92,7 +92,7 @@ class UpgradeSchema extends BaseSchema implements UpgradeSchemaInterface
         }
 
         /*
-         * add index to payone_protocoll_api::txid to speed up transactional api calls
+         * add index to payone_protocol_api::txid to speed up transaction status calls
          */
         if (version_compare($context->getVersion(), '2.3.1', '<=')) {
 

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -30,6 +30,7 @@ use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Magento\Framework\DB\Ddl\Table;
+use Payone\Core\Setup\Tables\Api;
 use Payone\Core\Setup\Tables\PaymentBan;
 
 /**
@@ -75,7 +76,7 @@ class UpgradeSchema extends BaseSchema implements UpgradeSchemaInterface
         if (!$setup->getConnection()->isTableExists($setup->getTable(PaymentBan::TABLE_PAYMENT_BAN))) {
             $this->addTable($setup, PaymentBan::getData());
         }
-        if (version_compare($context->getVersion(), '2.3.0', '<=')) {// pre update version is lower than 1.3.0
+        if (version_compare($context->getVersion(), '2.3.0', '<=')) {
             $setup->getConnection()->modifyColumn(
                 $setup->getTable('payone_protocol_api'),
                 'mid', ['type' => Table::TYPE_INTEGER, 'default' => '0']
@@ -87,6 +88,22 @@ class UpgradeSchema extends BaseSchema implements UpgradeSchemaInterface
             $setup->getConnection()->modifyColumn(
                 $setup->getTable('payone_protocol_api'),
                 'portalid', ['type' => Table::TYPE_INTEGER, 'default' => '0']
+            );
+        }
+
+        /*
+         * add index to payone_protocoll_api::txid to speed up transactional api calls
+         */
+        if (version_compare($context->getVersion(), '2.3.1', '<=')) {
+
+            $connection = $setup->getConnection();
+            $protocolApiTable = $connection->getTableName(Api::TABLE_PROTOCOL_API);
+            $indexField = 'txid';
+
+            $connection->addIndex(
+                $protocolApiTable,
+                $connection->getIndexName($protocolApiTable, $indexField),
+                $indexField
             );
         }
     }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -26,12 +26,13 @@
 
 namespace Payone\Core\Setup;
 
+use Magento\Framework\DB\Ddl\Table;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
-use Magento\Framework\DB\Ddl\Table;
 use Payone\Core\Setup\Tables\Api;
 use Payone\Core\Setup\Tables\PaymentBan;
+use Payone\Core\Setup\Tables\Transactionstatus;
 
 /**
  * Magento script for updating the database after the initial installation
@@ -41,7 +42,7 @@ class UpgradeSchema extends BaseSchema implements UpgradeSchemaInterface
     /**
      * Upgrade method
      *
-     * @param  SchemaSetupInterface   $setup
+     * @param  SchemaSetupInterface $setup
      * @param  ModuleContextInterface $context
      * @return void
      */
@@ -104,6 +105,21 @@ class UpgradeSchema extends BaseSchema implements UpgradeSchemaInterface
                 $protocolApiTable,
                 $connection->getIndexName($protocolApiTable, $indexField),
                 $indexField
+            );
+
+            $transactionStatusTable = $connection->getTableName(Transactionstatus::TABLE_PROTOCOL_TRANSACTIONSTATUS);
+            $indexFieldTxid = 'txid';
+            $indexFieldCustomerid = 'customerid';
+
+            $connection->addIndex(
+                $transactionStatusTable,
+                $connection->getIndexName($transactionStatusTable, $indexFieldTxid),
+                $indexFieldTxid
+            );
+            $connection->addIndex(
+                $transactionStatusTable,
+                $connection->getIndexName($transactionStatusTable, $indexFieldCustomerid),
+                $indexFieldCustomerid
             );
         }
     }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -25,7 +25,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Payone_Core" setup_version="2.3.1">
+    <module name="Payone_Core" setup_version="2.3.2">
         <sequence>
             <module name="Magento_Quote" />
             <module name="Magento_Sales" />


### PR DESCRIPTION
- Transaction status messages identify the according order by the txid. The column had no index
and therefore those requests may have consumed some time when a lot of transactions are held in
this table.
- Remove wrong duplicated comment

In our scenario the order lookup in transaction status processing could be reduced from 1.4 to 1.7 seconds (no query_cache) to 200ms to 300ms.

*Repro*
1. Run `bin/magento setup:upgrade`
1. check structure of table `payone_protocol_api`
   1. An index `PAYONE_PROTOCOL_API_TXID` exists