### PR TITLE
Fix account ID and portal ID are stored as smallint in transactionstatus table

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -130,6 +130,27 @@ class UpgradeSchema extends BaseSchema implements UpgradeSchemaInterface
                 'portalid', ['type' => Table::TYPE_INTEGER, 'default' => '0']
             );
         }
+
+        if (version_compare($context->getVersion(), '2.5.1', '<')) {
+            $setup->getConnection()->modifyColumn(
+                $setup->getTable('payone_protocol_transactionstatus'),
+                'aid',
+                [
+                    'type' => Table::TYPE_INTEGER,
+                    'unsigned' => true,
+                    'default' => '0'
+                ]
+            );
+            $setup->getConnection()->modifyColumn(
+                $setup->getTable('payone_protocol_transactionstatus'),
+                'portalid',
+                [
+                    'type' => Table::TYPE_INTEGER,
+                    'unsigned' => true,
+                    'default' => '0'
+                ]
+            );
+        }
     }
 
     /**

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -25,7 +25,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Payone_Core" setup_version="2.5.0">
+    <module name="Payone_Core" setup_version="2.5.1">
         <sequence>
             <module name="Magento_Quote" />
             <module name="Magento_Sales" />


### PR DESCRIPTION
This fixes an issue if account ID or portal ID is greater than 65535.

It is stored correctly in payone_protocol_api as integer but in payone_protocol_transactionstatus it is stored as smallint.