### PR TITLE
Changed creation of refunded items according to the given creditmemo …

### DIFF
--- a/Model/Api/Request/Debit.php
+++ b/Model/Api/Request/Debit.php
@@ -101,7 +101,23 @@ class Debit extends Base
      */
     protected function getInvoiceList(Order $oOrder, Creditmemo $oCreditmemo)
     {
-        $aCreditmemo = $this->getCreditmemoRequestParams();
+        $aCreditmemo = [
+            'items' => [],
+            'do_offline' => '0',
+            'comment_text' => '',
+            'shipping_amount' => '0',
+            'adjustment_positive' => '0',
+            'adjustment_negative' => '0'
+        ];
+
+        $items = [];
+        foreach ($oCreditmemo->getAllItems() as $item) {
+            if ($item->getQty() <= 0 || $item->getOrderItem()->isDummy()) continue;
+
+            $items[$item->getOrderItemId()] = ['qty' => $item->getQty()];
+        }
+
+        $aCreditmemo['items'] = $items;
 
         $aPositions = [];
         $blFull = true;


### PR DESCRIPTION
…instead of request object, so that refunds can also be done via API or on console where a request object is not available


This PR is an enhancement for using the extension in an environment where no request object is available (i.e. on console or via Magento API). Until now your extension only works manually in the backend, but enterprise projects won't use it that way.

It was already discussed [here](https://github.com/PAYONE-GmbH/magento-2/issues/92) and is exactly the same problem [here](https://github.com/PAYONE-GmbH/magento-2/issues/213)

Please keep in mind that the PR still calls the function `getCreditmemoRequestParams()` in line 195, I didn't want to change it as this PR is only an idea how to fix that problem in general. Maybe you can use this idea to fix your extension, so that it can also be used automatically on console or Magento API.