### PR TITLE
Fix problem with $aPaymentMethods index not set.

### DIFF
--- a/Model/Plugins/MethodList.php
+++ b/Model/Plugins/MethodList.php
@@ -226,7 +226,7 @@ class MethodList
     public function removeAmazonPay($aPaymentMethods)
     {
         for($i = 0; $i < count($aPaymentMethods); $i++) {
-            if ($aPaymentMethods[$i]->getCode() == PayoneConfig::METHOD_AMAZONPAY) {
+            if (isset($aPaymentMethods[$i]) && $aPaymentMethods[$i]->getCode() == PayoneConfig::METHOD_AMAZONPAY) {
                 unset($aPaymentMethods[$i]);
             }
         }


### PR DESCRIPTION
If you ban a payment method via `removeBannedPaymentMethods`, the index of that payment method becomes empty.

`removeAmazonPay` is being ran after this method, which causes `$aPaymentMethods[$i]` to throw an error for the bannedPaymentMethod.