### PR TITLE
Fix missing status in response in case of curl timeouts. Fixes #148

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -150,7 +150,7 @@ class Api extends Base
 
         if (!array_key_exists('status', $aResponse)) {
             $aResponse['status'] = 'ERROR';
-            $aResponse['errorcode'] = '903';
+            $aResponse['errorcode'] = '0';
             $aResponse['customermessage'] = 'No connection to external service provider possible (timeout)';
         }
 

--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -148,6 +148,12 @@ class Api extends Base
 
         $aResponse = $this->formatOutputByResponse($aResponse);
 
+        if (!array_key_exists('status', $aResponse)) {
+            $aResponse['status'] = 'ERROR';
+            $aResponse['errorcode'] = '903';
+            $aResponse['customermessage'] = 'No connection to external service provider possible (timeout)';
+        }
+
         return $aResponse;
     }
 


### PR DESCRIPTION
We sometimes see exceptions when the status is missing in the API response. This is also mentioned in #148 

I would assume if the status is missing we set it to "ERROR". The following code then requires the keys  "errorcode" and "customermessage" set in Model/Methods/PayoneMethod.php line 151

https://github.com/PAYONE-GmbH/magento-2/blob/master/Model/Methods/PayoneMethod.php#L151