### PR TITLE
Extend array for AmazonPayButton Observer

### DIFF
--- a/Observer/AddAmazonPayButton.php
+++ b/Observer/AddAmazonPayButton.php
@@ -79,7 +79,7 @@ class AddAmazonPayButton implements ObserverInterface
         $shortcutButtons = $observer->getEvent()->getContainer();
 
         $blIsSsl = $this->storeManager->getStore()->isCurrentlySecure();
-        if (!$blIsSsl || in_array($shortcutButtons->getNameInLayout(), ['addtocart.shortcut.buttons', 'addtocart.shortcut.buttons.additional'])) {
+        if (!$blIsSsl || in_array($shortcutButtons->getNameInLayout(), ['addtocart.shortcut.buttons', 'addtocart.shortcut.buttons.additional', 'map.shortcut.buttons'])) {
             return;
         }
 


### PR DESCRIPTION
If you have the AmazonPay Module enabled and navigate to 
magento2-checkout in magento2-ee version 2.1.17, there are 2 events fired
to the observer. This results to the AmazonPay Button not being
rendered in the Checkout. By ignoring the 'map.shortcut.buttons'
fired by module-msrp, the AmazonPayButton is being rendered correctly