### PR TITLE
Fixes path to privacyDeclaration for Debit method

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/payolution_debit-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payolution_debit-method.js
@@ -100,10 +100,10 @@ define(
                 $('#' + this.getCode() + '_overlay').hide();
             },
             getPrivacyDeclaration: function () {
-                return window.checkoutConfig.payment.payone.payolution.privacyDeclaration.invoice;
+                return window.checkoutConfig.payment.payone.payolution.privacyDeclaration.debit;
             },
             isB2bMode: function () {
-                if (window.checkoutConfig.payment.payone.payolution.b2bMode.invoice == true &&
+                if (window.checkoutConfig.payment.payone.payolution.b2bMode.debit == true &&
                     quote.billingAddress() != null &&
                     typeof quote.billingAddress().company != 'undefined' &&
                     quote.billingAddress().company != ''


### PR DESCRIPTION
In case Payolution Invoice method is disabled in your M2 project, you'll get "false" returned as a content of getPrivacyDeclaration() method after you click "acceptance" link on the storefront. Backend prepared separate privacy declaration for each of payolution methods but only invoice is used for all payolution payment methods, which seems to be a bug to me. After proposed changes everything looks good