### PR TITLE
Changes deprecated function name, sets is_customer_notified to false …

### DIFF
--- a/Model/Handler/Cancellation.php
+++ b/Model/Handler/Cancellation.php
@@ -77,10 +77,12 @@ class Cancellation
         if ($this->checkoutSession->getPayoneCustomerIsRedirected()) {
             try {
                 $orderId = $this->checkoutSession->getLastOrderId();
+                /** @var Order $order */
                 $order = $orderId ? $this->orderFactory->create()->load($orderId) : false;
                 if ($order) {
                     $order->cancel();
-                    $order->addStatusHistoryComment(__('The Payone transaction has been canceled.'), Order::STATE_CANCELED);
+                    $order
+                        ->addStatusToHistory(Order::STATE_CANCELED, __('The Payone transaction has been canceled.'), false);
                     $order->save();
 
                     $oCurrentQuote = $this->checkoutSession->getQuote();

--- a/Model/TransactionStatus/Mapping.php
+++ b/Model/TransactionStatus/Mapping.php
@@ -76,7 +76,7 @@ class Mapping
             $sStatus = $aStatusMapping[$sAction];
 
             $sMsg = 'Received PAYONE status "'.$sAction.'". Order set to "'.$sStatus.'" by PAYONE StatusMapping';
-            $oOrder->addStatusHistoryComment($sMsg, $sStatus);
+            $oOrder->addStatusToHistory($sStatus, $sMsg, false);
 
             $sState = $this->databaseHelper->getStateByStatus($sStatus);
             if ($sState) {


### PR DESCRIPTION
Changes deprecated function name, sets is_customer_notified to false for order status comments preventing "null" values in the database which prevent fetching order information via SOAP API.