### PR TITLE
Noticket: Increase TX-Status forwarding timeout

### DIFF
--- a/Model/TransactionStatus/Forwarding.php
+++ b/Model/TransactionStatus/Forwarding.php
@@ -123,7 +123,9 @@ class Forwarding
      */
     public function forwardAsyncRequest($aPostArray, $sUrl)
     {
-        $this->curl->setOption(CURLOPT_TIMEOUT_MS, 100);
+	// Increased timeout to 5500ms
+	// See payone-gmbh/magento-2 issue #316
+        $this->curl->setOption(CURLOPT_TIMEOUT_MS, 5500);
         $this->curl->setOption(CURLOPT_SSL_VERIFYPEER, false);
         $this->curl->setOption(CURLOPT_SSL_VERIFYHOST, false);
         try {


### PR DESCRIPTION
Fixes #316 

This is the "quick and dirty" variant of a fix for the mentioned issue.

It would be nicer to have a real async forwarding process, making use either of a cron job (bad memories from Magento 1), or RabbitMQ if available.