### PR TITLE
Gift card is counted twice when discount form cart price rule is enabled

### DIFF
--- a/Model/Api/Invoice.php
+++ b/Model/Api/Invoice.php
@@ -163,8 +163,8 @@ class Invoice
         if ($aPositions === false || $blFirstCapture === true || $blDebit === true) {
             $this->addShippingItem($oOrder, $aPositions, $blDebit, $dShippingCosts); // add shipping invoice params to request
             $this->addGiftCardItem($oOrder);  // add gift card invoice params to request
-            $this->addAmastyGiftcards($oOrder, $aPositions, $blDebit); // add amasty giftcard invoice params to request
             $this->addDiscountItem($oOrder, $aPositions, $blDebit); // add discount invoice params to request
+            $this->addAmastyGiftcards($oOrder, $aPositions, $blDebit); // add amasty giftcard invoice params to request
         }
         return $this->dAmount;
     }

--- a/Model/Api/Invoice.php
+++ b/Model/Api/Invoice.php
@@ -162,9 +162,9 @@ class Invoice
 
         if ($aPositions === false || $blFirstCapture === true || $blDebit === true) {
             $this->addShippingItem($oOrder, $aPositions, $blDebit, $dShippingCosts); // add shipping invoice params to request
-            $this->addDiscountItem($oOrder, $aPositions, $blDebit); // add discount invoice params to request
             $this->addGiftCardItem($oOrder);  // add gift card invoice params to request
             $this->addAmastyGiftcards($oOrder, $aPositions, $blDebit); // add amasty giftcard invoice params to request
+            $this->addDiscountItem($oOrder, $aPositions, $blDebit); // add discount invoice params to request
         }
         return $this->dAmount;
     }

--- a/Test/Unit/Model/Api/InvoiceTest.php
+++ b/Test/Unit/Model/Api/InvoiceTest.php
@@ -120,18 +120,29 @@ class InvoiceTest extends BaseTestCase
         $this->amastyHelper->method('getAmastyGiftCards')->willReturn([['base_gift_amount' => 5, 'gift_amount' => 5, 'code' => 'TEST']]);
 
         $authorization = $this->getMockBuilder(Authorization::class)->disableOriginalConstructor()->getMock();
-
+        
         $items = [$this->getItemMock()];
+        
+        $expected = 75;
 
-        $expected = 85;
-
-        $order = $this->getMockBuilder(Order::class)->disableOriginalConstructor()->getMock();
+        $order = $this->getMockBuilder(Order::class)
+            ->setMethods([
+                'getAllItems',
+                'getBaseShippingInclTax',
+                'getBaseDiscountAmount',
+                'getCouponCode',
+                'getBaseGrandTotal',
+                'getStore',
+                'getGiftCards'
+            ])
+            ->disableOriginalConstructor()->getMock();
         $order->method('getAllItems')->willReturn($items);
         $order->method('getBaseShippingInclTax')->willReturn(-5);
         $order->method('getBaseDiscountAmount')->willReturn(-5);
         $order->method('getCouponCode')->willReturn('test');
         $order->method('getBaseGrandTotal')->willReturn($expected);
         $order->method('getStore')->willReturn($this->store);
+        $order->method('getGiftCards')->willReturn('[{"i":365,"c":"testcode","a":10,"ba":10,"authorized":10}]');
 
         $result = $this->classToTest->addProductInfo($authorization, $order, false);
         $this->assertEquals($expected, $result);
@@ -147,9 +158,21 @@ class InvoiceTest extends BaseTestCase
 
         $items = [$this->getItemMock()];
 
-        $expected = 101;
+        $expected = 91;
 
-        $order = $this->getMockBuilder(Order::class)->disableOriginalConstructor()->getMock();
+        $order = $this->getMockBuilder(Order::class)
+            ->setMethods([
+                'getAllItems',
+                'getBaseShippingInclTax',
+                'getShippingInclTax',
+                'getBaseDiscountAmount',
+                'getDiscountAmount',
+                'getCouponCode',
+                'getBaseGrandTotal',
+                'getGrandTotal',
+                'getStore',
+                'getGiftCards'
+            ])->disableOriginalConstructor()->getMock();
         $order->method('getAllItems')->willReturn($items);
         $order->method('getBaseShippingInclTax')->willReturn(-5);
         $order->method('getShippingInclTax')->willReturn(-7);
@@ -159,6 +182,7 @@ class InvoiceTest extends BaseTestCase
         $order->method('getBaseGrandTotal')->willReturn($expected);
         $order->method('getGrandTotal')->willReturn($expected);
         $order->method('getStore')->willReturn($this->store);
+        $order->method('getGiftCards')->willReturn('[{"i":365,"c":"testcode","a":10,"ba":10,"authorized":10}]');
 
         $result = $this->classToTest->addProductInfo($authorization, $order, false);
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
When gift card and cart price rule is enabled, the gift card amount is counted twice.
In the function `addDiscountItem` the diff between order amount and quote amount with discount is calculated before gift card is added.
This `diff` has value of gift card and increase the discount amount.

There is the code responsible for adding the gift card amount to the discount.
// The calculations broken down to single items of Magento2 are unprecise and the Payone API will send an error if
// the calculated positions don't match, so we compensate for rounding-problems here
https://github.com/PAYONE-GmbH/magento-2/blob/master/Model/Api/Invoice.php#L277