### PR TITLE
MAG2-184: Fix for empty creditcard-type in Info-block

### DIFF
--- a/Block/Info/Creditcard.php
+++ b/Block/Info/Creditcard.php
@@ -39,8 +39,10 @@ class Creditcard extends Base
     protected function getCreditcardType($sShortType)
     {
         $aTypes = CreditcardTypes::getCreditcardTypes();
-        if (array_key_exists($sShortType, $aTypes) !== false) {
-            return $aTypes[$sShortType]['name'];
+        foreach ($aTypes as $aTypeEntry) {
+            if ($aTypeEntry['cardtype'] === $sShortType) {
+                return $aTypeEntry['name'];
+            }
         }
         return '';
     }


### PR DESCRIPTION
*Reason for the change*
During the changes in https://github.com/PAYONE-GmbH/magento-2/commit/342404b808c772145ab3465daa3131ac2144cab7#diff-57bbdd480bb30e81d51d4183f83e3b47c0347f0658a1793e054f3739c44ef065 the structure of the array was changed, but the implementation of getCreditcardType does not represent those changes up to now.
As the Payone-Server still returns the 1-letter code of the creditcard-type (e.g. 'V' for Visa) the current implementation finds no entry in the array and returns an empty string.
This results in an empty creditcard-type entry in the order-details of the Magento backend and order confirmation e-mails.

*Steps to verify the change*
- Place an order with payment-method creditcard, wait for appointed-call to arrive
- Check order details in Magento backend and order-confirmation e-mail for filled creditcard-type