### PR TITLE
Fix creditcard cardholder is not saved on first entry

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/creditcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcard-method.js
@@ -68,7 +68,7 @@ define(
                 if (this.isSaveDataEnabled()) {
                     parentReturn.additional_data.saveData = this.saveData();
                     parentReturn.additional_data.selectedData = this.getSelectedSavedCardPan();
-                    if (parentReturn.additional_data.selectedData !== 'new') {
+                    if (parentReturn.additional_data.selectedData !== 'new' && this.useSaveDataMode()) {
                         parentReturn.additional_data.cardholder = this.getSelectedSavedCardholder();
                     }
                 }


### PR DESCRIPTION
This fixes https://github.com/PAYONE-GmbH/magento-2/issues/428

If the user has no saved cards, getSelectedSavedCardPan() will return undefined, causing the condition in line 71 to become true.

getSelectedCardholder() will return false if the user has no saved card selected, overwriting the actual cardholder value from the form with an incorrect value.

I've fixed this by including a check for useSaveDataMode(), which returns false if user has no saved cards yet.