### PR TITLE
rely on proxy mode config only

### DIFF
--- a/Helper/Environment.php
+++ b/Helper/Environment.php
@@ -69,13 +69,12 @@ class Environment extends \Payone\Core\Helper\Base
     /**
      * Get the IP of the requesting client
      *
-     * @param  bool $blUseHttpXForwarded
      * @return string
      */
-    public function getRemoteIp($blUseHttpXForwarded = false)
+    public function getRemoteIp()
     {
         $blProxyMode = (bool)$this->getConfigParam('proxy_mode', 'processing', 'payone_misc');
-        if ($blUseHttpXForwarded === true && $blProxyMode === true) {
+        if ($blProxyMode === true) {
             $this->remoteAddress->useHttpXForwarded();
         }
         return $this->remoteAddress->getRemoteAddress();
@@ -88,7 +87,7 @@ class Environment extends \Payone\Core\Helper\Base
      */
     public function isRemoteIpValid()
     {
-        $sRemoteIp = $this->getRemoteIp(true);
+        $sRemoteIp = $this->getRemoteIp();
         $sValidIps = $this->getConfigParam('valid_ips', 'processing', 'payone_misc');
         $aWhitelist = explode("\n", $sValidIps ?? '');
         $aWhitelist = array_filter(array_map('trim', $aWhitelist));


### PR DESCRIPTION
To transfer the correct IP address to Payone while using proxy mode, the function parameter has to be removed, due payment requests are calling this function without a parameter, this leads the problem that the IP of a loadbalancer is transferred to Payone:
https://github.com/PAYONE-GmbH/magento-2/blob/master/Model/Api/Request/Genericpayment/PreCheck.php#L92
https://github.com/PAYONE-GmbH/magento-2/blob/master/Model/Api/Request/Authorization.php#L164
https://github.com/PAYONE-GmbH/magento-2/blob/master/Model/Api/Request/PaydirektAgreement.php#L82

If my assumption is correct the config for Proxy-Mode inside of Transaction-Status Processing should be moved to General -> Global Settings of the module, because it's used for Payment Requests and Transaction-Status Processing.