### PR TITLE
version bump to 350

### DIFF
--- a/Model/PayoneConfig.php
+++ b/Model/PayoneConfig.php
@@ -32,7 +32,7 @@ namespace Payone\Core\Model;
 abstract class PayoneConfig
 {
     /* Module version */
-    const MODULE_VERSION = '3.4.2';
+    const MODULE_VERSION = '3.5.0';
 
     /* Authorization request types */
     const REQUEST_TYPE_PREAUTHORIZATION = 'preauthorization';

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "payone-gmbh/magento-2",
     "description": "PAYONE payment gateway for all German online and offline payment methods including PayPal, all major Credit Cards and Maestro.",
     "type": "magento2-module",
-    "version": "3.4.2",
+    "version": "3.5.0",
     "license": [
       "OSL-3.0",
       "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -25,7 +25,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Payone_Core" setup_version="3.4.2">
+    <module name="Payone_Core" setup_version="3.5.0">
         <sequence>
             <module name="Magento_Quote" />
             <module name="Magento_Sales" />


### PR DESCRIPTION
New Features
 
* Add validation if birthday is a valid date
* Compatibility for Magento 2.4.4 and PHP 8.1
* New payment method: Ratepay Direct Debit 
* New payment method: Ratepay Installment
* Saved creditcard data will be filtered by available credit card providers 

Bugfixes
 
* Fixed unserialize problems with encoding
* Changed iDeal clearing information template
* Fixed creditcard cardholder is not saved on first entry
* Fixed cardtypes in hosted iframe config for cvc validation
* Ratepay javascripts now only loaded if method is activated
* Fixed display of creditcard data in order overview
* Fixed cardtypes in hosted iframe config for cvc validation
* Fixed XSS flaw in checkout

Maintenance
 
* Updated iDeal bankgrouptypes
* Add missing translation for Place Order button

Tested with Magento 2.4.4 with PHP 8.1