### PR TITLE
allow academic title in credit card holder name

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/creditcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcard-method.js
@@ -178,7 +178,7 @@ define(
                 return false;
             },
             isCardholderDataValid: function (sCardholder) {
-                if (sCardholder.search(/[^a-zA-ZÄäÖöÜüß\- ]+/) === -1) {
+                if (sCardholder.search(/[^a-zA-ZÄäÖöÜüß\-\. ]+/) === -1) {
                     return true;
                 }
                 return false;


### PR DESCRIPTION
A customer complained about not being able to enter his academic title ("Dr.") in the credit card holder field. This change enables customers to enter "." in the credit card holder field.