### PR TITLE
klarna base removed by false array key

### DIFF
--- a/Model/Plugins/MethodList.php
+++ b/Model/Plugins/MethodList.php
@@ -215,12 +215,12 @@ class MethodList
     protected function removeBannedPaymentMethods($aPaymentMethods, Quote $oQuote)
     {
         $aBannedMethos = $this->getBannedPaymentMethods($oQuote);
-        for($i = 0; $i < count($aPaymentMethods); $i++) {
-            $sCode = $aPaymentMethods[$i]->getCode();
+        foreach ($aPaymentMethods as $key => $aPaymentMethod) {
+            $sCode = $aPaymentMethod->getCode();
             if (array_key_exists($sCode, $aBannedMethos) !== false) {
                 $iBannedUntil = strtotime($aBannedMethos[$sCode]);
                 if ($iBannedUntil > time()) {
-                    unset($aPaymentMethods[$i]);
+                    unset($aPaymentMethods[$key]);
                 }
             }
         }
@@ -237,10 +237,9 @@ class MethodList
     {
         $aWhitelist = $this->checkoutSession->getPayonePaymentWhitelist();
         if (!empty($aWhitelist)) {
-            $iCount = count($aPaymentMethods);
-            for($i = 0; $i < $iCount; $i++) {
-                if (array_search($aPaymentMethods[$i]->getCode(), $aWhitelist) === false) {
-                    unset($aPaymentMethods[$i]);
+            foreach ($aPaymentMethods as $key => $aPaymentMethod) {
+                if (!in_array($aPaymentMethod->getCode(), $aWhitelist)) {
+                    unset($aPaymentMethods[$key]);
                 }
             }
         }
@@ -255,9 +254,9 @@ class MethodList
      */
     public function removeAmazonPay($aPaymentMethods)
     {
-        for($i = 0; $i < count($aPaymentMethods); $i++) {
-            if (isset($aPaymentMethods[$i]) && $aPaymentMethods[$i]->getCode() == PayoneConfig::METHOD_AMAZONPAY) {
-                unset($aPaymentMethods[$i]);
+        foreach ($aPaymentMethods as $key => $aPaymentMethod) {
+            if ($aPaymentMethod->getCode() == PayoneConfig::METHOD_AMAZONPAY) {
+                unset($aPaymentMethods[$key]);
             }
         }
         return $aPaymentMethods;
@@ -278,18 +277,15 @@ class MethodList
             PayoneConfig::METHOD_KLARNA_DEBIT,
             PayoneConfig::METHOD_KLARNA_INSTALLMENT
         ];
-        for($i = 0; $i < count($aPaymentMethods); $i++) {
-            if (isset($aPaymentMethods[$i])) {
-                if ($aPaymentMethods[$i]->getCode() == PayoneConfig::METHOD_KLARNA_BASE) {
-                    $iKeyKlarna = $i;
-                }
-                if (in_array($aPaymentMethods[$i]->getCode(), $aKlarnaSubtypes) === true) {
-                    $blHasKlarnaSubtypes = true;
-                    break;
-                }
+        foreach ($aPaymentMethods as $key => $aPaymentMethod) {
+            if ($aPaymentMethod->getCode() == PayoneConfig::METHOD_KLARNA_BASE) {
+                $iKeyKlarna = $key;
+            }
+            if (in_array($aPaymentMethod->getCode(), $aKlarnaSubtypes) === true) {
+                $blHasKlarnaSubtypes = true;
+                break;
             }
         }
-
         if ($iKeyKlarna !== false && $blHasKlarnaSubtypes === false) {
             unset($aPaymentMethods[$iKeyKlarna]);
         }


### PR DESCRIPTION
A customer has brought to our attention that the payment method Klarna no longer appears.
After debugging, I found the error. 
**\Payone\Core\Model\Plugins\MethodList::checkKlarnaMethods**

![image](https://user-images.githubusercontent.com/43909416/211782740-c67bbe77-a81c-4936-a981-a5de40981292.png)

The error is in the for loop. 
In case of a certain order of the payment methods, an unset is set to the wrong key and the Klarna payment methods do not appear anymore. 

The error occurs only when Klarna is in the last position as payment method (klarna base and **only one** of the klarna payment methods).

**Steps to reproduce**
1. Enable multiple payment methods in Payone (Klarna Base included)
2. activate only one Klarna payment method (one of Klarna "Pay Later", Klarna "Pay Now" or Klarna "Slice It")
3. klarna should be the last activated payment method, please do not activate any payment methods after klarna
4. disable the standrad Magento payment methods (checkmo)
5. go to checkout

Result: 
All payment methods set in Payone, except Klarna, can be seen