### PR TITLE
forwardAsyncRequest: Follow 301 Redirects to the End Location

### DIFF
--- a/Model/TransactionStatus/Forwarding.php
+++ b/Model/TransactionStatus/Forwarding.php
@@ -128,7 +128,7 @@ class Forwarding
         $this->curl->setOption(CURLOPT_TIMEOUT_MS, 5500);
         $this->curl->setOption(CURLOPT_SSL_VERIFYPEER, false);
         $this->curl->setOption(CURLOPT_SSL_VERIFYHOST, false);
-	$this->curl->setOption(CURLOPT_FOLLOWLOCATION, true); // Follow 301 Redirects to the End Location 
+	$this->curl->setOption(CURLOPT_FOLLOWLOCATION, true);
         try {
             $this->curl->post($sUrl, $aPostArray);
         } catch (\Exception $exc) {

--- a/Model/TransactionStatus/Forwarding.php
+++ b/Model/TransactionStatus/Forwarding.php
@@ -128,6 +128,7 @@ class Forwarding
         $this->curl->setOption(CURLOPT_TIMEOUT_MS, 5500);
         $this->curl->setOption(CURLOPT_SSL_VERIFYPEER, false);
         $this->curl->setOption(CURLOPT_SSL_VERIFYHOST, false);
+	$this->curl->setOption(CURLOPT_FOLLOWLOCATION, true); // Follow 301 Redirects to the End Location 
         try {
             $this->curl->post($sUrl, $aPostArray);
         } catch (\Exception $exc) {


### PR DESCRIPTION
# forwardAsyncRequest: Follow 301 Redirects to the End Location

## Problem Description

If a server is not properly configured, specific internal routes, such as `"payone/transactionstatus/decouple"`, could be relocated due to `"301 Moved Permanently"` status. In this case, the POST request in forwardAsyncRequest fails to operate as expected. This impacts for example the TransactionStatus Forwarding mechanism, as the request doesn't follow through the redirect and no further functions are called.

This issue became evident after the implementation of varnish cache on our server. Our server had a flaw where the calls to `"payone/transactionstatus/decouple"` weren't whitelisted directly (301 moved permanently), thereby inhibiting the TransactionStatus from being correctly forwarded. This issue was harder to narrow down due to a lack of logging.

![grafik](https://github.com/PAYONE-GmbH/magento-2/assets/96877646/96906a7c-dadc-4124-91ba-2588936ecaf6)


## Solution

In order to avoid this behavior i added `CURLOPT_FOLLOWLOCATION` to this Post Request. This should solve these unforeseen behaviours and 301 Redirects will be followed until the end Locaiton. Therefore overall less customers will experience these problems.
