### PR TITLE
version bump to 390

### DIFF
--- a/Model/PayoneConfig.php
+++ b/Model/PayoneConfig.php
@@ -32,7 +32,7 @@ namespace Payone\Core\Model;
 abstract class PayoneConfig
 {
     /* Module version */
-    const MODULE_VERSION = '3.8.1';
+    const MODULE_VERSION = '3.9.0';
 
     /* Authorization request types */
     const REQUEST_TYPE_PREAUTHORIZATION = 'preauthorization';

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "payone-gmbh/magento-2",
     "description": "PAYONE payment gateway for all German online and offline payment methods including PayPal, all major Credit Cards and Maestro.",
     "type": "magento2-module",
-    "version": "3.8.1",
+    "version": "3.9.0",
     "license": [
       "OSL-3.0",
       "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -25,7 +25,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Payone_Core" setup_version="3.8.1">
+    <module name="Payone_Core" setup_version="3.9.0">
         <sequence>
             <module name="Magento_Quote" />
             <module name="Magento_Sales" />


### PR DESCRIPTION
New Features
 
* Klarna B2B invoice now used the Billie widget
* Added compatibility to Magento 2.4.6 and PHP 8.2
* Implement B2B payments for BNPL Secured Invoice

Bugfixes
 
* Fixed problem with different tax rate in PayPal Express
* Update de_DE.csv for correct umlaut display - Thanks to @splendidinternet
* Update Forwarding.php - Thanks to @nicolasbachmaier

Maintenance
 
* Hide Klarna debit and installment for B2B orders
* Tested with 2.4.6 