### PR TITLE
Fix XML syntax error

### DIFF
--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -45,7 +45,7 @@
         </method>
         <method name="payone_paypalv2">
             <allow_multiple_address>0</allow_multiple_address>
-        </method>v
+        </method>
         <method name="payone_advance_payment">
             <allow_multiple_address>0</allow_multiple_address>
         </method>


### PR DESCRIPTION
Removes a syntax error that causes:

The XML in file "/var/www/magento/htdocs/vendor/payone-gmbh/magento-2/etc/payment.xml" is invalid:
Element 'methods': Character content other than whitespace is not allowed because the content type is 'element-only'.