### PR TITLE
Fix XML error in admin panel route

### DIFF
--- a/view/adminhtml/ui_component/payone_protocol_api_grid.xml
+++ b/view/adminhtml/ui_component/payone_protocol_api_grid.xml
@@ -84,7 +84,6 @@
         </settings>
         <column name="id">
             <settings>
-                <indexField>id</indexField>
                 <sorting>desc</sorting>
                 <label translate="true">ID</label>
             </settings>

--- a/view/adminhtml/ui_component/payone_protocol_transactionstatus_grid.xml
+++ b/view/adminhtml/ui_component/payone_protocol_transactionstatus_grid.xml
@@ -84,7 +84,6 @@
         </settings>
         <column name="id">
             <settings>
-                <indexField>id</indexField>
                 <sorting>desc</sorting>
                 <label translate="true">ID</label>
             </settings>
@@ -162,4 +161,3 @@
         </actionsColumn>
     </columns>
 </listing>
-


### PR DESCRIPTION
Fixes #578

Fix the XML error 'Element 'indexField': This element is not expected' in the admin panel route `payone/protocol_transactionstatus/index`.

* Remove the `<indexField>id</indexField>` element from the `<column name="id">` section in `view/adminhtml/ui_component/payone_protocol_transactionstatus_grid.xml`.
* Remove the `<indexField>id</indexField>` element from the `<column name="id">` section in `view/adminhtml/ui_component/payone_protocol_api_grid.xml`.

