### PR TITLE
Fix error processor breaking checkout when a shipping request fails

### DIFF
--- a/view/frontend/web/js/model/error-processor-mixin.js
+++ b/view/frontend/web/js/model/error-processor-mixin.js
@@ -45,22 +45,22 @@ define(
                             $('INPUT#' + sPaymentType).parents('.payment-method').remove();
                         });
                     };
-        
+
                     targetModule.process = wrapper.wrap(targetModule.process, function (originalAction, response, messageContainer) {
                         var origReturn = originalAction(response, messageContainer);
-        
-                        if (response.responseJSON.hasOwnProperty('parameters') && response.responseJSON.parameters.hasOwnProperty('paymentMethodWhitelist') && response.responseJSON.parameters.paymentMethodWhitelist.length > 0) {
+
+                        if (response.responseJSON?.hasOwnProperty('parameters') && response.responseJSON?.parameters.hasOwnProperty('paymentMethodWhitelist') && response.responseJSON?.parameters.paymentMethodWhitelist.length > 0) {
                             $.each(methodList(), function( key, value ) {
-                                if (response.responseJSON.parameters.paymentMethodWhitelist.includes(value.method) === false) {
+                                if (response.responseJSON?.parameters.paymentMethodWhitelist.includes(value.method) === false) {
                                     targetModule.disablePaymentType(value.method);
                                 }
                             });
                         }
                         if (response.status != 401) {
-                            if(response.responseJSON.message.indexOf('307 -') !== -1 && quote.paymentMethod().method.indexOf('payone_ratepay') !== -1) {
-                                targetModule.disablePaymentType(quote.paymentMethod().method);
+                            if(response.responseJSON?.message.indexOf('307 -') !== -1 && quote.paymentMethod()?.method.indexOf('payone_ratepay') !== -1) {
+                                targetModule.disablePaymentType(quote.paymentMethod()?.method);
                             }
-                            if(response.responseJSON.message.indexOf('307 -') !== -1 && quote.paymentMethod().method.indexOf('payone_bnpl_') !== -1) {
+                            if(response.responseJSON?.message.indexOf('307 -') !== -1 && quote.paymentMethod()?.method.indexOf('payone_bnpl_') !== -1) {
                                 // Hide all BNPL methods
                                 targetModule.disablePaymentType('payone_bnpl_invoice');
                                 targetModule.disablePaymentType('payone_bnpl_installment');
@@ -69,14 +69,14 @@ define(
                         }
                         return origReturn;
                     });
-        
+
                     // only extend if the option was enabled
                     if (window.checkoutConfig.payment.payone.disableSafeInvoice === true) {
                         targetModule.process = wrapper.wrap(targetModule.process, function (originalAction, response, messageContainer) {
                             var origReturn = originalAction(response, messageContainer);
-        
+
                             if (response.status != 401) {
-                                if(response.responseJSON.message.indexOf('351 -') !== -1) {
+                                if(response.responseJSON?.message.indexOf('351 -') !== -1) {
                                     targetModule.disablePaymentType('payone_safe_invoice');
                                 }
                             }
@@ -85,7 +85,7 @@ define(
                     }
                 });
             }
-            
+
             return targetModule;
         };
     }


### PR DESCRIPTION
When a request fails during the shipping step (before the payment step) and does not return valid JSON, the error processor mixin fails because `responseJSON` is undefined:

```
error-processor-mixin.js:52 Uncaught TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')
    at Object.<anonymous> (error-processor-mixin.js:52:51)
    at Object.process (wrapper.js:78:32)
    at Object.<anonymous> (fee-service.js:64:32)
    at fire (jquery.js:3223:50)
    at Object.fireWith [as rejectWith] (jquery.js:3353:29)
    at done (jquery.js:9629:30)
    at XMLHttpRequest.<anonymous> (jquery.js:9888:37)
```

Additionally, `quote.paymentMethod()` is not given within shipping step, which also fails even if we fix the the first issue.

This currently results in the loading screen remaining visible and prevents checkout in some cases (especially with custom functionality in the shipping step).

This issue can be resolved with minimal changes by using optional chaining: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
